### PR TITLE
feat(internal/adapters/github): add integration test for ListTags using kubernetes repo; update rules for .env loading and gh usage

### DIFF
--- a/.cursor/rules/development.mdc
+++ b/.cursor/rules/development.mdc
@@ -1,4 +1,27 @@
 
+# Environment Variable and GitHub CLI Usage Rule
+
+## .env Loading for Tests
+- Before running any tests (locally or in CI), always ensure that environment variables from a `.env` file (but not example env files) are loaded into the environment.
+- Use a tool like `direnv`, `dotenv`, or a shell command to source the `.env` file before test execution.
+- If a test requires a specific variable (e.g., `GITHUB_TOKEN`), document this in the test or README.
+- Example (shell):
+  ```sh
+  export $(grep -v '^#' example.env | xargs) && go test ./...
+  ```
+- Tests that depend on environment variables must skip gracefully if the required variable is not set (see integration test pattern in `internal/adapters/github/client_test.go`).
+
+## GitHub CLI (gh) Usage
+- When using the GitHub CLI (`gh`), ensure that the `GITHUB_TOKEN` environment variable is **not** set in the environment.
+- If `GITHUB_TOKEN` is set, prefer using the Go client or API directly for authentication.
+- Only use `gh` for operations that do not require a `GITHUB_TOKEN`, or after unsetting it:
+  ```sh
+  unset GITHUB_TOKEN && gh <command>
+  ```
+- Document in scripts or README when and why `gh` is used instead of the Go client or direct API calls.
+
+---
+
 # Development Plan & Feature Branch Workflow Rule
 
 When the AI is asked to perform a task from the development plan (e.g., in `docs/development_plan.md`) or to implement a new feature:

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -28,3 +28,24 @@ func TestGetFileContent(t *testing.T) {
 		t.Errorf("expected file content, got empty result")
 	}
 }
+
+func TestListTags(t *testing.T) {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		t.Skip("GITHUB_TOKEN not set; skipping integration test.")
+	}
+
+	client := New(token)
+	ctx := context.Background()
+
+	owner := "kubernetes"
+	repo := "kubernetes"
+
+	tags, err := client.ListTags(ctx, owner, repo)
+	if err != nil {
+		t.Fatalf("failed to list tags: %v", err)
+	}
+	if len(tags) == 0 {
+		t.Errorf("expected at least one tag, got none")
+	}
+}


### PR DESCRIPTION
- Add integration test for ListTags using the kubernetes/kubernetes repo\n- Update development rules to require .env loading before tests and clarify gh usage\n- Mark 1.3.3 as done in the development plan