### PR TITLE
refactor: add Go build cache mounting for Dagger IntegrationTests and UnitTests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
   integration-tests:
     name: Run integration tests
     if: github.event_name == 'pull_request'
-    needs: [lint]
+    needs: [lint, unit-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -37,3 +37,17 @@ jobs:
           args: integration-tests --source-dir=. --github-token=env:GITHUB_TOKEN
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+
+  unit-tests:
+    name: Run unit tests
+    if: github.event_name == 'pull_request'
+    needs: [lint]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dagger/dagger-for-github@8.0.0
+        with:
+          version: latest
+          verb: call
+          args: unit-tests --source-dir=. 


### PR DESCRIPTION
This PR refactors the Dagger IntegrationTests and UnitTests to use a shared helper for mounting Go build caches and setting up the workdir. This should speed up test runs and keep the code DRY.\n\n- Adds withGoCodeAndCacheAsWorkDirectory helper\n- Mounts /root/.cache/go-build and /go/pkg/mod for both test pipelines\n- Updates CI to use the new cache-enabled test jobs\n\nCloses # (if applicable)